### PR TITLE
Fix host hooks implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Currently supports the following databases:
 - passwd
 - shadow
 - group
+- hosts
 
 ## Getting started
 - Create a new library

--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -7,7 +7,7 @@ extern crate libnss;
 use libnss::passwd::{PasswdHooks, Passwd};
 use libnss::group::{GroupHooks, Group};
 use libnss::shadow::{ShadowHooks, Shadow};
-use libnss::host::{Addresses, Host, HostHooks};
+use libnss::host::{AddressFamily, Addresses, Host, HostHooks};
 
 struct HardcodedPasswd;
 libnss_passwd_hooks!(hardcoded, HardcodedPasswd);
@@ -176,8 +176,8 @@ impl HostHooks for HardcodedHost {
         }
     }
 
-    fn get_host_by_name(name: &str) -> Option<Host> {
-        if name.ends_with(".example") {
+    fn get_host_by_name(name: &str, family: AddressFamily) -> Option<Host> {
+        if name.ends_with(".example") && family == AddressFamily::IPv4 {
             Some(Host {
                 name: name.to_string(),
                 addresses: Addresses::V4(vec![Ipv4Addr::new(177, 42, 42, 42)]),

--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -7,7 +7,7 @@ extern crate libnss;
 use libnss::passwd::{PasswdHooks, Passwd};
 use libnss::group::{GroupHooks, Group};
 use libnss::shadow::{ShadowHooks, Shadow};
-use libnss::host::{HostHooks, Host};
+use libnss::host::{Addresses, Host, HostHooks};
 
 struct HardcodedPasswd;
 libnss_passwd_hooks!(hardcoded, HardcodedPasswd);
@@ -145,21 +145,46 @@ impl ShadowHooks for HardcodedShadow {
     }
 }
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 struct HardcodedHost;
 libnss_host_hooks!(hardcoded, HardcodedHost);
 
 impl HostHooks for HardcodedHost {
     fn get_all_entries() -> Vec<Host> {
-        unimplemented!()
+        vec![Host {
+            name: "test.example".to_string(),
+            addresses: Addresses::V4(vec![Ipv4Addr::new(177, 42, 42, 42)]),
+            aliases: vec!["other.example".to_string()],
+        }]
     }
 
-    fn get_host_by_name(_name: &str) -> Option<Host> {
-        unimplemented!()
+    fn get_host_by_addr(addr: IpAddr) -> Option<Host> {
+        match addr {
+            IpAddr::V4(addr) => {
+                if addr.octets() == [177, 42, 42, 42] {
+                    Some(Host {
+                        name: "test.example".to_string(),
+                        addresses: Addresses::V4(vec![Ipv4Addr::new(177, 42, 42, 42)]),
+                        aliases: vec!["other.example".to_string()],
+                    })
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
-    fn get_host_by_addr(_addr: IpAddr) -> Option<Host> {
-        unimplemented!()
+    fn get_host_by_name(name: &str) -> Option<Host> {
+        if name.ends_with(".example") {
+            Some(Host {
+                name: name.to_string(),
+                addresses: Addresses::V4(vec![Ipv4Addr::new(177, 42, 42, 42)]),
+                aliases: vec!["test.example".to_string(), "other.example".to_string()],
+            })
+        } else {
+            None
+        }
     }
 }

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -1,6 +1,5 @@
 use crate::interop::CBuffer;
 use std::collections::VecDeque;
-use std::mem;
 
 pub struct Group {
     pub name: String,
@@ -14,21 +13,7 @@ impl Group {
         (*pwbuf).name = buffer.write_str(self.name);
         (*pwbuf).passwd = buffer.write_str(self.passwd);
         (*pwbuf).gid = self.gid;
-
-        // Allocate array
-        let ptr_size = mem::size_of::<*mut libc::c_char>() as isize;
-        let mut array_pos = buffer.reserve(ptr_size * ((self.members.len() + 1) as isize)) as *mut *mut libc::c_char;
-        (*pwbuf).members = array_pos;
-
-        // Store elements
-        for member in self.members {
-            // Store string
-            let pos = buffer.write_str(member);
-            *array_pos = pos;
-
-            // Offset pointer
-            array_pos = array_pos.offset(1);
-        }
+        (*pwbuf).members = buffer.write_strs(&self.members);
     }
 }
 

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -37,7 +37,7 @@ impl Host {
         };
 
         let mut array_pos =
-            buffer.reserve(ptr_size * (count as isize) + 1) as *mut *mut libc::c_char;
+            buffer.reserve(ptr_size * (count as isize + 1)) as *mut *mut libc::c_char;
         (*hostent).h_addr_list = array_pos;
 
         match &self.addresses {
@@ -53,7 +53,7 @@ impl Host {
                     );
 
                     *array_pos = ptr;
-                    array_pos = array_pos.offset(1);
+                    array_pos = array_pos.offset(ptr_size);
                 }
             }
             Addresses::V6(addrs) => {
@@ -68,7 +68,7 @@ impl Host {
                     );
 
                     *array_pos = ptr;
-                    array_pos = array_pos.offset(1);
+                    array_pos = array_pos.offset(ptr_size);
                 }
             }
         }
@@ -93,7 +93,7 @@ pub trait HostHooks {
 #[derive(Debug)]
 pub struct CHost {
     pub name: *mut libc::c_char,
-    pub h_aliases: *mut libc::c_char,
+    pub h_aliases: *mut *mut libc::c_char,
     pub h_addrtype: libc::c_int,
     pub h_length: libc::c_int,
     pub h_addr_list: *mut *mut libc::c_char,

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -174,7 +174,7 @@ macro_rules! libnss_host_hooks {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyaddr_r>](addr: *const libc::c_char, len: libc::size_t, format: libc::c_int, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, result: *mut *mut CHost, _errnop: *mut libc::c_int) -> libc::c_int {
+            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyaddr_r>](addr: *const libc::c_char, len: libc::size_t, format: libc::c_int, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, _errnop: *mut libc::c_int, _herrnop: *mut libc::c_int) -> libc::c_int {
                 // Convert address type
                 let a = match (len, format) {
                     (4, libc::AF_INET) => {
@@ -206,8 +206,8 @@ macro_rules! libnss_host_hooks {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyname_r>](name_: *const libc::c_char, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, result: *mut *mut CHost, _errnop: *mut libc::c_int) -> libc::c_int {
-                let cstr = CStr::from_ptr(name_);
+            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyname_r>](name: *const libc::c_char, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, _errnop: *mut libc::c_int, _herrnop: *mut libc::c_int) -> libc::c_int {
+                let cstr = CStr::from_ptr(name);
 
                 match str::from_utf8(cstr.to_bytes()) {
                     Ok(name) => match super::$hooks_ident::get_host_by_name(&name.to_string()) {

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -75,9 +75,6 @@ impl Host {
 
         // Write null termination
         libc::memset(array_pos as *mut libc::c_void, 0, 1);
-
-        // Set single / first address
-        (*hostent).h_addr = *(*hostent).h_addr_list;
     }
 }
 
@@ -93,13 +90,13 @@ pub trait HostHooks {
 /// https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_chapter/libc_16.html#SEC318
 #[repr(C)]
 #[allow(missing_copy_implementations)]
+#[derive(Debug)]
 pub struct CHost {
     pub name: *mut libc::c_char,
     pub h_aliases: *mut libc::c_char,
     pub h_addrtype: libc::c_int,
     pub h_length: libc::c_int,
     pub h_addr_list: *mut *mut libc::c_char,
-    pub h_addr: *mut libc::c_char,
 }
 
 pub struct HostIterator {

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -206,7 +206,14 @@ macro_rules! libnss_host_hooks {
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyname_r>](name: *const libc::c_char, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, _errnop: *mut libc::c_int, _herrnop: *mut libc::c_int) -> libc::c_int {
+            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyname_r>](name: *const libc::c_char, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, errnop: *mut libc::c_int, herrnop: *mut libc::c_int) -> libc::c_int {
+                [<_nss_ $mod_ident _gethostbyname2_r>](name, libc::AF_UNSPEC, hostbuf, buf, buflen, errnop, herrnop)
+            }
+
+            // TODO: if `family` is specified but wrong family of addresses is returned, should be
+            // an error
+            #[no_mangle]
+            unsafe extern "C" fn [<_nss_ $mod_ident _gethostbyname2_r>](name: *const libc::c_char, family: libc::c_int, hostbuf: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t, _errnop: *mut libc::c_int, _herrnop: *mut libc::c_int) -> libc::c_int {
                 let cstr = CStr::from_ptr(name);
 
                 match str::from_utf8(cstr.to_bytes()) {

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -26,8 +26,6 @@ impl Host {
         (*hostent).name = buffer.write_str(self.name);
         (*hostent).h_aliases = buffer.write_strs(&self.aliases);
 
-        let ptr_size = mem::size_of::<*mut libc::c_char>() as isize;
-
         let (addr_len, count) = match &self.addresses {
             Addresses::V4(addrs) => {
                 (*hostent).h_addrtype = libc::AF_INET;
@@ -43,6 +41,7 @@ impl Host {
             }
         };
 
+        let ptr_size = mem::size_of::<*mut libc::c_char>() as isize;
         let mut array_pos =
             buffer.reserve(ptr_size * (count as isize + 1)) as *mut *mut libc::c_char;
         (*hostent).h_addr_list = array_pos;
@@ -60,7 +59,7 @@ impl Host {
                     );
 
                     *array_pos = ptr;
-                    array_pos = array_pos.offset(ptr_size);
+                    array_pos = array_pos.offset(1);
                 }
             }
             Addresses::V6(addrs) => {
@@ -75,7 +74,7 @@ impl Host {
                     );
 
                     *array_pos = ptr;
-                    array_pos = array_pos.offset(ptr_size);
+                    array_pos = array_pos.offset(1);
                 }
             }
         }

--- a/libnss/src/interop.rs
+++ b/libnss/src/interop.rs
@@ -75,7 +75,7 @@ impl CBuffer {
         // Write strings
         for s in strings {
             *pos = self.write_str(s.to_string());
-            pos = pos.offset(ptr_size);
+            pos = pos.offset(1);
         }
 
         libc::memset(pos as *mut libc::c_void, 0, ptr_size as usize);

--- a/libnss/src/interop.rs
+++ b/libnss/src/interop.rs
@@ -66,20 +66,21 @@ impl CBuffer {
         str_start as *mut libc::c_char
     }
 
-    pub unsafe fn write_strs(&mut self, strings: &[String]) -> *mut libc::c_char {
-        // Capture start address
-        let str_start = self.pos;
+    pub unsafe fn write_strs(&mut self, strings: &[String]) -> *mut *mut libc::c_char {
+        let ptr_size = std::mem::size_of::<*mut libc::c_char>() as isize;
+
+        let vec_start = self.reserve(ptr_size * (strings.len() as isize + 1)) as *mut *mut libc::c_char;
+        let mut pos = vec_start;
+
         // Write strings
         for s in strings {
-            self.write_str(s.clone());
+            *pos = self.write_str(s.to_string());
+            pos = pos.offset(ptr_size);
         }
-        // Write null to end
-        libc::memset(self.pos, 0, 1);
-        // Update end address
-        self.pos.offset(1);
-        self.free -= 1;
 
-        str_start as *mut libc::c_char
+        libc::memset(pos as *mut libc::c_void, 0, ptr_size as usize);
+
+        vec_start
     }
 
     pub unsafe fn reserve(&mut self, len: isize) -> *mut libc::c_char {


### PR DESCRIPTION
This is a follow-up from my comments in #1 

* ~Fixed (I think) pointer offsetting~ actually, I think it was already correct
* Removed `h_addr` field from struct (it [appears to be `#define`d not actually structural](https://code.woboq.org/userspace/glibc/resolv/netdb.h.html#hostent))
* **IMPORTANT** Fixed the way `h_aliases` is written (it should be a null-terminated vector of pointers which each point to a C-string containing the alias, but instead was written as sequential strings)
* added `_nss_<module>_gethostbyname2_r`, as `*_gethostbyname_r` was never called in my glibc. I've left the original which calls v2 but it may need further attention.
* filled in the example module with some implemented `hosts` hooks
* fixed module functions signature (I think). It seems that @ryankurte based the signature on the following, from [glibc manual](https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_chapter/libc_16.html#SEC318):

  ``` c
  int gethostbyname_r (const char *restrict name,
                       struct hostent *restrict result_buf,
                       char *restrict buf,
                       size_t buflen,
                       struct hostent **restrict result,
                       int *restrict h_errnop)
  ```

  While this has both `struct hostent *result_buf` and a `struct hostent **result` (the latter apparently being a pointer into the former), every NSS module implementation I could find in the wild as well the [NSS portion of the glibc manual](https://www.gnu.org/software/libc/manual/html_node/NSS-Modules-Interface.html#NSS-Modules-Interface) gives the following interface and explanation for NSS functions:


  ``` c
  enum nss_status _nss_files_gethostbyname_r (const char *name,
                                              struct hostent
                                              *result_buf,
                                              char *buf,
                                              size_t buflen,
                                              int *errnop,
                                              int *h_errnop)
  ```

  > I.e., the interface function is in fact the reentrant function with the change of the return value, the omission of the result parameter, and the addition of the errnop parameter. While the user-level function returns a pointer to the result the reentrant function return an enum nss_status value: 

Please give any feedback you'd like. I ran `cargo fmt` but decided not to commit those changes as it changed a LOT of source (for the better, FWIW) and I didn't want to muddy the diff too much.

I'd _like_ to do some follow-up work, too:

* Add `_nss_<module>_gethostbyname3_r`, though based on [`getaddrinfo`](https://code.woboq.org/userspace/glibc/sysdeps/posix/getaddrinfo.c.html#837), this isn't expected to exist for most implementations and it falls back to v2 smoothly.
* Add `_nss_<module>_gethostbyname4_r`; I've only done some preliminary research here, but it _appears_ this would allow returning heterogeneous address types (i.e. IPv4 + IPv6 addresses).
* Adjust the hook to be a general interface and wire all versions of hooks to it
* Evolve all hooks to return the `NssStatus` enum (or a new enum) instead of an `Option<T>`, so that hooks can decide to communicate various NSS statuses, by parameterising `Success`:
  
  ``` rust
  pub enum NssStatus<T> {
      TryAgain,
      Unavail,
      NotFound,
      Success<T>,
      Return,
  }
  ```
* Handle buffer-too-small cases by returning `ERANGE` instead of `panic!`ing.
* _see_ if there are some ways to less of the code `unsafe`

*EDIT*: the very-much-just-now-getting-started usage of these changes is [here](https://github.com/bjeanes/nss_zerotier), if you'd like any kind of test case.

<details><summary>References</summary>


* https://code.woboq.org/userspace/glibc/resolv/netdb.h.html#hostent
* https://code.woboq.org/userspace/glibc/sysdeps/posix/getaddrinfo.c.html#837
* https://github.com/lathiat/nss-mdns/blob/58fcdd2071eb64372f071cee14982536fd4c7a99/src/util.c#L176
* https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_chapter/libc_16.html#SEC318
* https://www.gnu.org/software/libc/manual/html_node/NSS-Modules-Interface.html#NSS-Modules-Interface
* https://github.com/lathiat/nss-mdns/blob/58fcdd2071eb64372f071cee14982536fd4c7a99/src/util.c#L176
* https://github.com/lathiat/nss-mdns/blob/58fcdd2071eb64372f071cee14982536fd4c7a99/src/nss.c#L215-L262
* (for research into `gethostbyname4_r`) https://lists.freedesktop.org/archives/systemd-devel/2013-February/008606.html
* (for research into `gethostbyname4_r`) https://github.com/lathiat/nss-mdns/blob/58fcdd2071eb64372f071cee14982536fd4c7a99/src/nss.c#L195-L213

other NSS modules:

* https://github.com/dimkr/nss-tls (C)
* https://github.com/lathiat/nss-mdns (C)
* https://github.com/badboy/libnss_dnsoverhttps (C + Rust) - blog post: https://fnordig.de/2018/02/09/doh-everything/
* https://github.com/outlook/libnss-aad (Rust)
</details>