### PR TITLE
Allow hook impls to set NSS status + more generics

### DIFF
--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -1,4 +1,4 @@
-use crate::interop::CBuffer;
+use crate::interop::{CBuffer, Response, ToC};
 
 pub struct Group {
     pub name: String,
@@ -7,26 +7,22 @@ pub struct Group {
     pub members: Vec<String>,
 }
 
-impl Group {
-    pub unsafe fn to_c_group(
-        self,
-        pwbuf: *mut CGroup,
-        buffer: &mut CBuffer,
-    ) -> std::io::Result<()> {
-        (*pwbuf).name = buffer.write_str(self.name)?;
-        (*pwbuf).passwd = buffer.write_str(self.passwd)?;
-        (*pwbuf).gid = self.gid;
-        (*pwbuf).members = buffer.write_strs(&self.members)?;
+impl ToC<CGroup> for Group {
+    unsafe fn to_c(&self, result: *mut CGroup, buffer: &mut CBuffer) -> std::io::Result<()> {
+        (*result).name = buffer.write_str(&self.name)?;
+        (*result).passwd = buffer.write_str(&self.passwd)?;
+        (*result).gid = self.gid;
+        (*result).members = buffer.write_strs(&self.members)?;
         Ok(())
     }
 }
 
 pub trait GroupHooks {
-    fn get_all_entries() -> Vec<Group>;
+    fn get_all_entries() -> Response<Vec<Group>>;
 
-    fn get_entry_by_gid(gid: libc::gid_t) -> Option<Group>;
+    fn get_entry_by_gid(gid: libc::gid_t) -> Response<Group>;
 
-    fn get_entry_by_name(name: String) -> Option<Group>;
+    fn get_entry_by_name(name: String) -> Response<Group>;
 }
 
 #[repr(C)]
@@ -46,10 +42,11 @@ macro_rules! libnss_group_hooks {
         mod [<libnss_group_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]
 
+            use libc::c_int;
             use std::ffi::CStr;
             use std::str;
             use std::sync::{Mutex, MutexGuard};
-            use $crate::interop::{CBuffer, Iterator, NssStatus};
+            use $crate::interop::{CBuffer, Iterator, Response};
             use $crate::group::{CGroup, GroupHooks, Group};
 
             lazy_static! {
@@ -57,117 +54,62 @@ macro_rules! libnss_group_hooks {
             }
 
             #[no_mangle]
-            extern "C" fn [<_nss_ $mod_ident _setgrent>]() -> libc::c_int {
+            extern "C" fn [<_nss_ $mod_ident _setgrent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                iter.open(super::$hooks_ident::get_all_entries());
-                NssStatus::Success.to_c()
+                let status = match(super::$hooks_ident::get_all_entries()) {
+                    Response::Success(records) => iter.open(records),
+                    response => response.to_status(),
+                };
+                status as c_int
             }
 
             #[no_mangle]
-            extern "C" fn [<_nss_ $mod_ident _endgrent>]() -> libc::c_int {
+            extern "C" fn [<_nss_ $mod_ident _endgrent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                iter.close();
-
-                NssStatus::Success.to_c()
+                iter.close() as c_int
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _getgrent_r>](pwbuf: *mut CGroup, buf: *mut libc::c_char, buflen: libc::size_t,
-                                                                  errnop: *mut libc::c_int) -> libc::c_int {
+            unsafe extern "C" fn [<_nss_ $mod_ident _getgrent_r>](
+                result: *mut CGroup,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                errnop: *mut c_int
+            ) -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                match iter.next() {
-                    None => $crate::interop::NssStatus::NotFound.to_c(),
-                    Some(entry) => {
-                        let mut buffer = CBuffer::new(buf as *mut libc::c_void, buflen);
-                        buffer.clear();
-
-                        match entry.to_c_group(pwbuf, &mut buffer) {
-                            Err(e) => {
-                                match e.raw_os_error() {
-                                   Some(e) =>{
-                                       *errnop = e;
-                                       NssStatus::TryAgain.to_c()
-                                   },
-                                   None => {
-                                       *errnop = libc::ENOENT;
-                                       NssStatus::Unavail.to_c()
-                                   }
-                               }
-                            },
-                            Ok(_) => {
-                                *errnop = 0;
-                                NssStatus::Success.to_c()
-                            }
-                        }
-                    }
-                }
+                iter.next().to_c(result, buf, buflen, errnop) as c_int
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _getgrgid_r>](uid: libc::gid_t, pwbuf: *mut CGroup, buf: *mut libc::c_char,
-                                                                  buflen: libc::size_t, errnop: *mut libc::c_int) -> libc::c_int {
-                match super::$hooks_ident::get_entry_by_gid(uid) {
-                    Some(val) => {
-                        let mut buffer = CBuffer::new(buf as *mut libc::c_void, buflen);
-                        buffer.clear();
-
-                        match val.to_c_group(pwbuf, &mut buffer) {
-                            Err(e) => {
-                                match e.raw_os_error() {
-                                   Some(e) =>{
-                                       *errnop = e;
-                                       NssStatus::TryAgain.to_c()
-                                   },
-                                   None => {
-                                       *errnop = libc::ENOENT;
-                                       NssStatus::Unavail.to_c()
-                                   }
-                               }
-                            },
-                            Ok(_) => {
-                                *errnop = 0;
-                                NssStatus::Success.to_c()
-                            }
-                        }
-                    },
-                    None => NssStatus::NotFound.to_c()
-                }
+            unsafe extern "C" fn [<_nss_ $mod_ident _getgrgid_r>](
+                uid: libc::gid_t,
+                result: *mut CGroup,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                errnop: *mut c_int
+            ) -> c_int {
+                super::$hooks_ident::get_entry_by_gid(uid).to_c(
+                    result,
+                    buf,
+                    buflen,
+                    errnop
+                ) as c_int
             }
 
             #[no_mangle]
-            unsafe extern "C" fn [<_nss_ $mod_ident _getgrnam_r>](name_: *const libc::c_char, pwbuf: *mut CGroup, buf: *mut libc::c_char,
-                                                                  buflen: libc::size_t, errnop: *mut libc::c_int) -> libc::c_int {
+            unsafe extern "C" fn [<_nss_ $mod_ident _getgrnam_r>](
+                name_: *const libc::c_char,
+                result: *mut CGroup,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                errnop: *mut c_int
+            ) -> c_int {
                 let cstr = CStr::from_ptr(name_);
 
                 match str::from_utf8(cstr.to_bytes()) {
-                    Ok(name) => match super::$hooks_ident::get_entry_by_name(name.to_string()) {
-                        Some(val) => {
-                            let mut buffer = CBuffer::new(buf as *mut libc::c_void, buflen);
-                            buffer.clear();
-
-                            match val.to_c_group(pwbuf, &mut buffer) {
-                                Err(e) => {
-                                    match e.raw_os_error() {
-                                       Some(e) =>{
-                                           *errnop = e;
-                                           NssStatus::TryAgain.to_c()
-                                       },
-                                       None => {
-                                           *errnop = libc::ENOENT;
-                                           NssStatus::Unavail.to_c()
-                                       }
-                                   }
-                                },
-                                Ok(_) => {
-                                    *errnop = 0;
-                                    NssStatus::Success.to_c()
-                                }
-                            }
-                        },
-                        None => NssStatus::NotFound.to_c()
-                    },
-                    Err(_) => NssStatus::NotFound.to_c()
-                }
+                    Ok(name) => super::$hooks_ident::get_entry_by_name(name.to_string()),
+                    Err(_) => Response::NotFound
+                }.to_c(result, buf, buflen, errnop) as c_int
             }
         }
     }

--- a/libnss/src/lib.rs
+++ b/libnss/src/lib.rs
@@ -1,8 +1,8 @@
-extern crate libc;
 extern crate lazy_static;
+extern crate libc;
 
+pub mod group;
+pub mod host;
 pub mod interop;
 pub mod passwd;
-pub mod group;
 pub mod shadow;
-pub mod host;


### PR DESCRIPTION
This switches away from the hooks using a simple Option type to one that
more closely reflects the underlying APIs, allowing the conveyance of
different types of failures.

Since this introduces an enum which holds any relevant returned value,
we can also consolidate a lot of the "to_c" logic into a trait and avoid
some repitition.

This should also be a pathway to more safety.

This includes the commit from #4 

