### PR TITLE
Implement initgroups support

### DIFF
--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -192,6 +192,7 @@ libnss_initgroups_hooks!(hardcoded, HardcodedInitgroups);
 
 impl InitgroupsHooks for HardcodedInitgroups {
     fn get_entries_by_user(user: String) -> Response<Vec<Group>> {
+        let _ = user;
         Response::Success(vec![Group {
             name: "initgroup1".to_string(),
             passwd: "".to_string(),
@@ -201,6 +202,11 @@ impl InitgroupsHooks for HardcodedInitgroups {
             name: "initgroup2".to_string(),
             passwd: "".to_string(),
             gid: 3006,
+            members: vec!["someone".to_string()],
+        }, Group {
+            name: "initgroup3".to_string(),
+            passwd: "".to_string(),
+            gid: 3007,
             members: vec!["someone".to_string()],
         }])
     }

--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -6,6 +6,7 @@ extern crate libnss;
 
 use libnss::group::{Group, GroupHooks};
 use libnss::host::{AddressFamily, Addresses, Host, HostHooks};
+use libnss::initgroups::InitgroupsHooks;
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
 use libnss::shadow::{Shadow, ShadowHooks};
@@ -183,5 +184,24 @@ impl HostHooks for HardcodedHost {
         } else {
             Response::NotFound
         }
+    }
+}
+
+struct HardcodedInitgroups;
+libnss_initgroups_hooks!(hardcoded, HardcodedInitgroups);
+
+impl InitgroupsHooks for HardcodedInitgroups {
+    fn get_entries_by_user(user: String) -> Response<Vec<Group>> {
+        Response::Success(vec![Group {
+            name: "initgroup1".to_string(),
+            passwd: "".to_string(),
+            gid: 3005,
+            members: vec!["someone".to_string()],
+        }, Group {
+            name: "initgroup2".to_string(),
+            passwd: "".to_string(),
+            gid: 3006,
+            members: vec!["someone".to_string()],
+        }])
     }
 }

--- a/libnss/src/initgroups.rs
+++ b/libnss/src/initgroups.rs
@@ -17,7 +17,7 @@ macro_rules! libnss_initgroups_hooks {
             use std::ffi::CStr;
             use std::mem;
             use std::slice;
-            use $crate::interop::{NssStatusm, Response};
+            use $crate::interop::{NssStatus, Response};
             use $crate::group::{CGroup, Group};
             use $crate::initgroups::InitgroupsHooks;
 
@@ -31,7 +31,7 @@ macro_rules! libnss_initgroups_hooks {
                 limit: libc::size_t,
                 errnop: *mut c_int,
             ) -> c_int {
-                let user = match str::from_utf8(CStr::from_ptr(name).to_bytes()) {
+                let user = match std::str::from_utf8(CStr::from_ptr(name).to_bytes()) {
                     Ok(x) => x.to_owned(),
                     Err(_) => {
                         *errnop = ENOENT;
@@ -55,7 +55,7 @@ macro_rules! libnss_initgroups_hooks {
                             Some(x.gid as libc::gid_t)
                         }
                     })
-                    .take(limit - *size)
+                    .take(limit - *start)
                     .collect::<Vec<libc::gid_t>>();
                 if groups.is_empty() {
                     return NssStatus::Success as c_int;
@@ -72,7 +72,7 @@ macro_rules! libnss_initgroups_hooks {
 
                 let group_array: &mut [libc::gid_t] = slice::from_raw_parts_mut(*groupsp, *size);
                 group_array[*start..*size].copy_from_slice(&groups);
-                *start = group_array.len() - 1;
+                *start = group_array.len();
 
                 NssStatus::Success as i32
             }

--- a/libnss/src/initgroups.rs
+++ b/libnss/src/initgroups.rs
@@ -1,0 +1,82 @@
+use crate::group::Group;
+use crate::interop::Response;
+
+pub trait InitgroupsHooks {
+    fn get_entries_by_user(user: String) -> Response<Vec<Group>>;
+}
+
+#[macro_export]
+macro_rules! libnss_initgroups_hooks {
+($mod_ident:ident, $hooks_ident:ident) => (
+    paste::item! {
+        pub use self::[<libnss_initgroups_ $mod_ident _hooks_impl>]::*;
+        mod [<libnss_initgroups_ $mod_ident _hooks_impl>] {
+            #![allow(non_upper_case_globals)]
+
+            use libc::{c_int, ENOENT};
+            use std::ffi::CStr;
+            use std::mem;
+            use std::slice;
+            use $crate::interop::{NssStatusm, Response};
+            use $crate::group::{CGroup, Group};
+            use $crate::initgroups::InitgroupsHooks;
+
+            #[no_mangle]
+            unsafe extern "C" fn [<_nss_ $mod_ident _initgroups_dyn>](
+                name: *const libc::c_char,
+                skipgroup: libc::gid_t,
+                start: *mut libc::size_t,
+                size: *mut libc::size_t,
+                mut groupsp: *mut *mut libc::gid_t,
+                limit: libc::size_t,
+                errnop: *mut c_int,
+            ) -> c_int {
+                let user = match str::from_utf8(CStr::from_ptr(name).to_bytes()) {
+                    Ok(x) => x.to_owned(),
+                    Err(_) => {
+                        *errnop = ENOENT;
+                        return NssStatus::NotFound as c_int;
+                    }
+                };
+
+                let groups: Vec<Group> = match super::$hooks_ident::get_entries_by_user(user) {
+                    Response::Success(records) => records,
+                    response => {
+                        *errnop = ENOENT;
+                        return response.to_status() as c_int;
+                    }
+                };
+                let groups = groups
+                    .into_iter()
+                    .filter_map(|x| {
+                        if x.gid == skipgroup {
+                            None
+                        } else {
+                            Some(x.gid as libc::gid_t)
+                        }
+                    })
+                    .take(limit - *size)
+                    .collect::<Vec<libc::gid_t>>();
+                if groups.is_empty() {
+                    return NssStatus::Success as c_int;
+                }
+
+                if *start + groups.len() != *size {
+                    let new_size = *start + groups.len();
+                    *groupsp = libc::realloc(
+                        *groupsp as *mut libc::c_void,
+                        new_size * mem::size_of::<libc::gid_t>(),
+                    ) as *mut libc::gid_t;
+                    *size = new_size;
+                }
+
+                let group_array: &mut [libc::gid_t] = slice::from_raw_parts_mut(*groupsp, *size);
+                group_array[*start..*size].copy_from_slice(&groups);
+                *start = group_array.len() - 1;
+
+                NssStatus::Success as i32
+            }
+        }
+    }
+)
+}

--- a/libnss/src/lib.rs
+++ b/libnss/src/lib.rs
@@ -3,6 +3,7 @@ extern crate libc;
 
 pub mod group;
 pub mod host;
+pub mod initgroups;
 pub mod interop;
 pub mod passwd;
 pub mod shadow;


### PR DESCRIPTION
Added support for the initgroups database via a new trait. Fulfills the `initgroups_dyn` function specified by [glibc][1].

Also added an initgroups implementation to example_hardcoded.

[1]: https://sourceware.org/git/?p=glibc.git;a=blob;f=nss/nss.h;h=c7437230a9993294f286c922c9708bc427bfc860;hb=HEAD#l174