### PR TITLE
Fixing types for Shadow|Passwd|Group structs

### DIFF
--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -3,7 +3,7 @@ use crate::interop::{CBuffer, Response, ToC};
 pub struct Group {
     pub name: String,
     pub passwd: String,
-    pub gid: libc::gid_t,
+    pub gid: u32,
     pub members: Vec<String>,
 }
 

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -11,7 +11,7 @@ impl ToC<CGroup> for Group {
     unsafe fn to_c(&self, result: *mut CGroup, buffer: &mut CBuffer) -> std::io::Result<()> {
         (*result).name = buffer.write_str(&self.name)?;
         (*result).passwd = buffer.write_str(&self.passwd)?;
-        (*result).gid = self.gid;
+        (*result).gid = self.gid as libc::gid_t;
         (*result).members = buffer.write_strs(&self.members)?;
         Ok(())
     }

--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -14,8 +14,8 @@ impl ToC<CPasswd> for Passwd {
     unsafe fn to_c(&self, result: *mut CPasswd, buffer: &mut CBuffer) -> std::io::Result<()> {
         (*result).name = buffer.write_str(&self.name)?;
         (*result).passwd = buffer.write_str(&self.passwd)?;
-        (*result).uid = self.uid;
-        (*result).gid = self.gid;
+        (*result).uid = self.uid as libc::uid_t;
+        (*result).gid = self.gid as libc::gid_t;
         (*result).gecos = buffer.write_str(&self.gecos)?;
         (*result).dir = buffer.write_str(&self.dir)?;
         (*result).shell = buffer.write_str(&self.shell)?;

--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -3,8 +3,8 @@ use crate::interop::{CBuffer, Response, ToC};
 pub struct Passwd {
     pub name: String,
     pub passwd: String,
-    pub uid: libc::uid_t,
-    pub gid: libc::gid_t,
+    pub uid: u32,
+    pub gid: u32,
     pub gecos: String,
     pub dir: String,
     pub shell: String,

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -3,13 +3,13 @@ use crate::interop::{CBuffer, Response, ToC};
 pub struct Shadow {
     pub name: String,
     pub passwd: String,
-    pub last_change: i64,
-    pub change_min_days: i64,
-    pub change_max_days: i64,
-    pub change_warn_days: i64,
-    pub change_inactive_days: i64,
-    pub expire_date: i64,
-    pub reserved: u64,
+    pub last_change: isize,
+    pub change_min_days: isize,
+    pub change_max_days: isize,
+    pub change_warn_days: isize,
+    pub change_inactive_days: isize,
+    pub expire_date: isize,
+    pub reserved: usize,
 }
 
 impl ToC<CShadow> for Shadow {

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -16,13 +16,13 @@ impl ToC<CShadow> for Shadow {
     unsafe fn to_c(&self, result: *mut CShadow, buffer: &mut CBuffer) -> std::io::Result<()> {
         (*result).name = buffer.write_str(&self.name)?;
         (*result).passwd = buffer.write_str(&self.passwd)?;
-        (*result).last_change = self.last_change;
-        (*result).change_min_days = self.change_min_days;
-        (*result).change_max_days = self.change_max_days;
-        (*result).change_warn_days = self.change_warn_days;
-        (*result).change_inactive_days = self.change_inactive_days;
-        (*result).expire_date = self.expire_date;
-        (*result).reserved = self.reserved;
+        (*result).last_change = self.last_change as libc::c_long;
+        (*result).change_min_days = self.change_min_days as libc::c_long;
+        (*result).change_max_days = self.change_max_days as libc::c_long;
+        (*result).change_warn_days = self.change_warn_days as libc::c_long;
+        (*result).change_inactive_days = self.change_inactive_days as libc::c_long;
+        (*result).expire_date = self.expire_date as libc::c_long;
+        (*result).reserved = self.reserved as libc::c_ulong;
         Ok(())
     }
 }

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -38,13 +38,13 @@ pub trait ShadowHooks {
 pub struct CShadow {
     pub name: *mut libc::c_char,
     pub passwd: *mut libc::c_char,
-    pub last_change: i64,
-    pub change_min_days: i64,
-    pub change_max_days: i64,
-    pub change_warn_days: i64,
-    pub change_inactive_days: i64,
-    pub expire_date: i64,
-    pub reserved: u64,
+    pub last_change: libc::c_long,
+    pub change_min_days: libc::c_long,
+    pub change_max_days: libc::c_long,
+    pub change_warn_days: libc::c_long,
+    pub change_inactive_days: libc::c_long,
+    pub expire_date: libc::c_long,
+    pub reserved: libc::c_ulong,
 }
 
 #[macro_export]


### PR DESCRIPTION
We've been using the `libnss` crate for one of our projects and we realized some problems with the Shadow struct when building the library for 32 bits architectures.
The CShadow struct was using i64 and u64 types for its numeric fields, but this creates some problems in 32 bits architectures. To fix it, we changed the types to libc::c_long and libc::c_ulong, which vary in size depending on which architecture is being used.
Also, seizing the opportunity, there were also some quality of life improvements made to the types used by the Rust structs in order to make them use standard Rust types and avoid exposing the libc types used internally by the API.

P.S.: Congrats on the work! The crate is very good and I hope that these suggestions will help to make it even better.