### PR TITLE
Fix for write_strs logic

### DIFF
--- a/libnss/src/interop.rs
+++ b/libnss/src/interop.rs
@@ -158,7 +158,7 @@ impl CBuffer {
 
         // Write strings
         for s in strings {
-            *pos = self.write_str(s.as_ref())?;
+            pos.write(self.write_str(s.as_ref())?);
             pos = pos.offset(1);
         }
 


### PR DESCRIPTION
Assigning the written string directly to the pointer was causing [issues with pointer alignment](https://github.com/ubuntu/aad-auth/issues/179), so we replaced the direct assignment by `ptr.write(str)`.