### PR TITLE
Fix try again logic if the buffer is too small

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libnss"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "libc",

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -1,5 +1,6 @@
 use crate::interop::{CBuffer, Response, ToC};
 
+#[derive(Clone)]
 pub struct Group {
     pub name: String,
     pub passwd: String,
@@ -46,7 +47,7 @@ macro_rules! libnss_group_hooks {
             use std::ffi::CStr;
             use std::str;
             use std::sync::{Mutex, MutexGuard};
-            use $crate::interop::{CBuffer, Iterator, Response};
+            use $crate::interop::{CBuffer, Iterator, Response, NssStatus};
             use $crate::group::{CGroup, GroupHooks, Group};
 
             lazy_static! {
@@ -77,7 +78,11 @@ macro_rules! libnss_group_hooks {
                 errnop: *mut c_int
             ) -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                iter.next().to_c(result, buf, buflen, errnop) as c_int
+                let code: c_int = iter.next().to_c(result, buf, buflen, errnop) as c_int;
+                if code == NssStatus::TryAgain as c_int {
+                    iter.previous();
+                }
+                return code;
             }
 
             #[no_mangle]

--- a/libnss/src/interop.rs
+++ b/libnss/src/interop.rs
@@ -75,11 +75,12 @@ impl<R> Response<R> {
 
 pub struct Iterator<T> {
     items: Option<VecDeque<T>>,
+    index: usize,
 }
 
-impl<T> Iterator<T> {
+impl<T: Clone> Iterator<T> {
     pub fn new() -> Self {
-        Iterator { items: None }
+        Iterator { items: None, index: 0 }
     }
     pub fn open(&mut self, items: Vec<T>) -> NssStatus {
         self.items = Some(VecDeque::from(items));
@@ -87,12 +88,21 @@ impl<T> Iterator<T> {
     }
 
     pub fn next(&mut self) -> Response<T> {
-        match self.items {
-            Some(ref mut items) => match items.pop_front() {
-                Some(entity) => Response::Success(entity),
+        let response = match self.items {
+            Some(ref mut items) => match items.get(self.index) {
+                Some(entity) => Response::Success(entity.clone()),
                 None => Response::NotFound,
             },
             None => Response::Unavail,
+        };
+        self.index += 1;
+
+        return response;
+    }
+
+    pub fn previous(&mut self) {
+        if self.index > 0 {
+            self.index -= 1;
         }
     }
 

--- a/libnss/src/interop.rs
+++ b/libnss/src/interop.rs
@@ -84,6 +84,7 @@ impl<T: Clone> Iterator<T> {
     }
     pub fn open(&mut self, items: Vec<T>) -> NssStatus {
         self.items = Some(VecDeque::from(items));
+        self.index = 0;
         NssStatus::Success
     }
 
@@ -108,6 +109,7 @@ impl<T: Clone> Iterator<T> {
 
     pub fn close(&mut self) -> NssStatus {
         self.items = None;
+        self.index = 0;
         NssStatus::Success
     }
 }


### PR DESCRIPTION
If we return error code try again (-2) and errnop ERANGE (34). And according to the protocol, the client must make the call again and, in turn, increase the buffer. But in this case, we never resubmit the record due to the current iterator logic.
https://github.com/csnewman/libnss-rs/blob/master/libnss/src/interop.rs#L89C1-L97C6
items.pop_front() is always executed. And we will never return to the previous record

