### PR TITLE
Fix pointer alignment in hostname lookup

### DIFF
--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -57,7 +57,7 @@ impl ToC<CHost> for Host {
                         addr_len as usize,
                     );
 
-                    *array_pos = ptr;
+                    array_pos.write(ptr);
                     array_pos = array_pos.offset(1);
                 }
             }
@@ -72,7 +72,7 @@ impl ToC<CHost> for Host {
                         addr_len as usize,
                     );
 
-                    *array_pos = ptr;
+                    array_pos.write(ptr);
                     array_pos = array_pos.offset(1);
                 }
             }


### PR DESCRIPTION
This fixes panics from to_c() for Host in some cases:

    misaligned pointer dereference: address must be a multiple of 0x8 but is 0x7fffc3e95a0c
    stack backtrace:
       0:     0x7efc266ea05c - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::had353521bdfe6a1b
       1:     0x7efc2671267c - core::fmt::write::h5116881e4ba70505
       2:     0x7efc266e776e - std::io::Write::write_fmt::h0684e4778b0f1da1
       3:     0x7efc266e9e44 - std::sys_common::backtrace::print::ha2bc5d90bda10440
       4:     0x7efc266eb4b3 - std::panicking::default_hook::{{closure}}::h74b1138882925124
       5:     0x7efc266eb1d4 - std::panicking::default_hook::hf6c5f972b9a72ab6
       6:     0x7efc266eba35 - std::panicking::rust_panic_with_hook::hfb65cfee1a41a51e
       7:     0x7efc266eb931 - std::panicking::begin_panic_handler::{{closure}}::h76a2a5be19fb8866
       8:     0x7efc266ea586 - std::sys_common::backtrace::__rust_end_short_backtrace::h72cadf48dff827a3
       9:     0x7efc266eb682 - rust_begin_unwind
      10:     0x7efc2643df88 - core::panicking::panic_nounwind_fmt::h0b87173153046cac
      11:     0x7efc2643e1fa - core::panicking::panic_misaligned_pointer_dereference::h1f54126f44f72a74
      12:     0x7efc266cd2c4 - <libnss::host::Host as libnss::interop::ToC<libnss::host::CHost>>::to_c::h6cb7834ced3cc481
                                   at /home/knowicki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libnss-0.5.0/src/host.rs:60:21
      13:     0x7efc26455e44 - libnss::interop::Response<R>::to_c::h1a8d3d10d4a06afd
                                   at /home/knowicki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libnss-0.5.0/src/interop.rs:54:19
      14:     0x7efc2645c0b9 - _nss_tatoo_gethostbyname2_r
                                   at /home/knowicki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libnss-0.5.0/src/host.rs:253:38
      15:     0x7efc2645bd7c - _nss_tatoo_gethostbyname3_r
                                   at /home/knowicki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libnss-0.5.0/src/host.rs:224:33
      16:     0x7efc27196397 - gethosts
      17:     0x7efc27199368 - getaddrinfo
      18:     0x559a1d13841a - <unknown>
      19:     0x7efc270def0a - __libc_start_call_main
      20:     0x7efc270defc5 - __libc_start_main_alias_2
      21:     0x559a1d139a11 - <unknown>
      22:                0x0 - <unknown>
    thread caused non-unwinding panic. aborting.