### PR TITLE
Self-contained macros and better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libnss"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,10 +6,8 @@ version = 3
 name = "example-hardcoded"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "libc",
  "libnss",
- "paste",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -28,25 +28,14 @@ crate-type = [ "cdylib" ]
 ```yaml
 [dependencies]
 libc = "0.2.0"
-lazy_static = "1.3.0"
-paste = "0.1"
-libnss = "0.1.0"
-```
-
-- Add the following to your ```src/main.rs```
-
-```rust
-extern crate libc;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate libnss;
+libnss = "0.7.0"
 ```
 
 - Implement a ```passwd``` database
 
 ```rust
 use libnss::passwd::{PasswdHooks, Passwd};
+use libnss::libnss_passwd_hooks;
 
 struct ExamplePasswd;
 libnss_passwd_hooks!(example, ExamplePasswd);

--- a/example-hardcoded/Cargo.toml
+++ b/example-hardcoded/Cargo.toml
@@ -10,6 +10,4 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 libc = "0.2"
-lazy_static = "1.4"
-paste = "1.0"
 libnss = { path = "../libnss" }

--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -193,21 +193,25 @@ libnss_initgroups_hooks!(hardcoded, HardcodedInitgroups);
 impl InitgroupsHooks for HardcodedInitgroups {
     fn get_entries_by_user(user: String) -> Response<Vec<Group>> {
         let _ = user;
-        Response::Success(vec![Group {
-            name: "initgroup1".to_string(),
-            passwd: "".to_string(),
-            gid: 3005,
-            members: vec!["someone".to_string()],
-        }, Group {
-            name: "initgroup2".to_string(),
-            passwd: "".to_string(),
-            gid: 3006,
-            members: vec!["someone".to_string()],
-        }, Group {
-            name: "initgroup3".to_string(),
-            passwd: "".to_string(),
-            gid: 3007,
-            members: vec!["someone".to_string()],
-        }])
+        Response::Success(vec![
+            Group {
+                name: "initgroup1".to_string(),
+                passwd: "".to_string(),
+                gid: 3005,
+                members: vec!["someone".to_string()],
+            },
+            Group {
+                name: "initgroup2".to_string(),
+                passwd: "".to_string(),
+                gid: 3006,
+                members: vec!["someone".to_string()],
+            },
+            Group {
+                name: "initgroup3".to_string(),
+                passwd: "".to_string(),
+                gid: 3007,
+                members: vec!["someone".to_string()],
+            },
+        ])
     }
 }

--- a/example-hardcoded/src/lib.rs
+++ b/example-hardcoded/src/lib.rs
@@ -1,15 +1,13 @@
-extern crate libc;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate libnss;
-
 use libnss::group::{Group, GroupHooks};
 use libnss::host::{AddressFamily, Addresses, Host, HostHooks};
 use libnss::initgroups::InitgroupsHooks;
 use libnss::interop::Response;
 use libnss::passwd::{Passwd, PasswdHooks};
 use libnss::shadow::{Shadow, ShadowHooks};
+use libnss::{
+    libnss_group_hooks, libnss_host_hooks, libnss_initgroups_hooks, libnss_passwd_hooks,
+    libnss_shadow_hooks,
+};
 
 struct HardcodedPasswd;
 libnss_passwd_hooks!(hardcoded, HardcodedPasswd);

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -57,7 +57,7 @@ macro_rules! libnss_group_hooks {
             #[no_mangle]
             extern "C" fn [<_nss_ $mod_ident _setgrent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                let status = match(super::$hooks_ident::get_all_entries()) {
+                let status = match(<super::$hooks_ident as GroupHooks>::get_all_entries()) {
                     Response::Success(records) => iter.open(records),
                     response => response.to_status(),
                 };
@@ -93,7 +93,7 @@ macro_rules! libnss_group_hooks {
                 buflen: libc::size_t,
                 errnop: *mut c_int
             ) -> c_int {
-                super::$hooks_ident::get_entry_by_gid(uid).to_c(
+                <super::$hooks_ident as GroupHooks>::get_entry_by_gid(uid).to_c(
                     result,
                     buf,
                     buflen,
@@ -112,7 +112,7 @@ macro_rules! libnss_group_hooks {
                 let cstr = CStr::from_ptr(name_);
 
                 match str::from_utf8(cstr.to_bytes()) {
-                    Ok(name) => super::$hooks_ident::get_entry_by_name(name.to_string()),
+                    Ok(name) => <super::$hooks_ident as GroupHooks>::get_entry_by_name(name.to_string()),
                     Err(_) => Response::NotFound
                 }.to_c(result, buf, buflen, errnop) as c_int
             }

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -38,7 +38,7 @@ pub struct CGroup {
 #[macro_export]
 macro_rules! libnss_group_hooks {
 ($mod_ident:ident, $hooks_ident:ident) => (
-    paste::item! {
+    $crate::_macro_internal::paste! {
         pub use self::[<libnss_group_ $mod_ident _hooks_impl>]::*;
         mod [<libnss_group_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]
@@ -50,7 +50,7 @@ macro_rules! libnss_group_hooks {
             use $crate::interop::{CBuffer, Iterator, Response, NssStatus};
             use $crate::group::{CGroup, GroupHooks, Group};
 
-            lazy_static! {
+            $crate::_macro_internal::lazy_static! {
             static ref [<GROUP_ $mod_ident _ITERATOR>]: Mutex<Iterator<Group>> = Mutex::new(Iterator::<Group>::new());
             }
 

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -1,7 +1,7 @@
 use crate::interop::{CBuffer, Response, ToC};
 use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-#[derive(Clone,Debug,PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Host {
     pub name: String,
     pub aliases: Vec<String>,
@@ -14,7 +14,7 @@ pub enum AddressFamily {
     IPv6,
     Unspecified,
 }
-#[derive(Clone,Debug,PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Addresses {
     V4(Vec<Ipv4Addr>),
     V6(Vec<Ipv6Addr>),

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -137,7 +137,7 @@ macro_rules! libnss_host_hooks {
             #[no_mangle]
             extern "C" fn [<_nss_ $mod_ident _sethostent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Host>> = [<HOST_ $mod_ident _ITERATOR>].lock().unwrap();
-                let status = match(super::$hooks_ident::get_all_entries()) {
+                let status = match(<super::$hooks_ident as HostHooks>::get_all_entries()) {
                     Response::Success(entries) => iter.open(entries),
                     response => response.to_status()
                 };
@@ -192,7 +192,7 @@ macro_rules! libnss_host_hooks {
                     }
                 };
 
-                match super::$hooks_ident::get_host_by_addr(a) {
+                match <super::$hooks_ident as HostHooks>::get_host_by_addr(a) {
                     response @ Response::Success(..) => {
                         *h_errnop = Herrno::NetDbSuccess as i32;
                         response
@@ -255,13 +255,13 @@ macro_rules! libnss_host_hooks {
                     Ok(name) => {
                         use super::$hooks_ident as hooks;
                         let status = match family {
-                            libc::AF_INET => hooks::get_host_by_name(&name.to_string(), AddressFamily::IPv4),
-                            libc::AF_INET6 => hooks::get_host_by_name(&name.to_string(), AddressFamily::IPv6),
+                            libc::AF_INET => <hooks as HostHooks>::get_host_by_name(&name.to_string(), AddressFamily::IPv4),
+                            libc::AF_INET6 => <hooks as HostHooks>::get_host_by_name(&name.to_string(), AddressFamily::IPv6),
 
                             // If unspecified, we are probably being called from gethostbyname_r so
                             // we will try IPv4 and if no results, then try IPv6
-                            libc::AF_UNSPEC => match hooks::get_host_by_name(&name.to_string(), AddressFamily::IPv4) {
-                                Response::NotFound => hooks::get_host_by_name(&name.to_string(), AddressFamily::IPv6),
+                            libc::AF_UNSPEC => match <hooks as HostHooks>::get_host_by_name(&name.to_string(), AddressFamily::IPv4) {
+                                Response::NotFound => <hooks as HostHooks>::get_host_by_name(&name.to_string(), AddressFamily::IPv6),
                                 val => val,
                             },
                             _ => {

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -108,7 +108,7 @@ pub struct CHost {
 #[macro_export]
 macro_rules! libnss_host_hooks {
 ($mod_ident:ident, $hooks_ident:ident) => (
-    paste::item! {
+    $crate::_macro_internal::paste! {
         pub use self::[<libnss_host_ $mod_ident _hooks_impl>]::*;
         mod [<libnss_host_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]
@@ -130,7 +130,7 @@ macro_rules! libnss_host_hooks {
                 NoData = 4,
             }
 
-            lazy_static! {
+            $crate::_macro_internal::lazy_static! {
             static ref [<HOST_ $mod_ident _ITERATOR>]: Mutex<Iterator<Host>> = Mutex::new(Iterator::<Host>::new());
             }
 

--- a/libnss/src/initgroups.rs
+++ b/libnss/src/initgroups.rs
@@ -8,7 +8,7 @@ pub trait InitgroupsHooks {
 #[macro_export]
 macro_rules! libnss_initgroups_hooks {
 ($mod_ident:ident, $hooks_ident:ident) => (
-    paste::item! {
+    $crate::_macro_internal::paste! {
         pub use self::[<libnss_initgroups_ $mod_ident _hooks_impl>]::*;
         mod [<libnss_initgroups_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]

--- a/libnss/src/initgroups.rs
+++ b/libnss/src/initgroups.rs
@@ -39,7 +39,7 @@ macro_rules! libnss_initgroups_hooks {
                     }
                 };
 
-                let groups: Vec<Group> = match super::$hooks_ident::get_entries_by_user(user) {
+                let groups: Vec<Group> = match <super::$hooks_ident as InitgroupsHooks>::get_entries_by_user(user) {
                     Response::Success(records) => records,
                     response => {
                         *errnop = ENOENT;

--- a/libnss/src/lib.rs
+++ b/libnss/src/lib.rs
@@ -1,9 +1,13 @@
-extern crate lazy_static;
-extern crate libc;
-
 pub mod group;
 pub mod host;
 pub mod initgroups;
 pub mod interop;
 pub mod passwd;
 pub mod shadow;
+
+/// Re-exports for use by macros
+#[doc(hidden)]
+pub mod _macro_internal {
+    pub use lazy_static::lazy_static;
+    pub use paste::paste;
+}

--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -67,7 +67,7 @@ macro_rules! libnss_passwd_hooks {
             extern "C" fn [<_nss_ $mod_ident _setpwent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Passwd>> = [<PASSWD_ $mod_ident _ITERATOR>].lock().unwrap();
 
-                let status = match(super::$hooks_ident::get_all_entries()) {
+                let status = match(<super::$hooks_ident as PasswdHooks>::get_all_entries()) {
                     Response::Success(entries) => iter.open(entries),
                     response => response.to_status()
                 };
@@ -104,7 +104,7 @@ macro_rules! libnss_passwd_hooks {
                 buflen: libc::size_t,
                 errnop: *mut c_int
             ) -> c_int {
-                super::$hooks_ident::get_entry_by_uid(uid).to_c(result, buf, buflen, errnop) as c_int
+                <super::$hooks_ident as PasswdHooks>::get_entry_by_uid(uid).to_c(result, buf, buflen, errnop) as c_int
             }
 
             #[no_mangle]
@@ -118,7 +118,7 @@ macro_rules! libnss_passwd_hooks {
                 let cstr = CStr::from_ptr(name_);
 
                 let response = match str::from_utf8(cstr.to_bytes()) {
-                    Ok(name) => super::$hooks_ident::get_entry_by_name(name.to_string()),
+                    Ok(name) => <super::$hooks_ident as PasswdHooks>::get_entry_by_name(name.to_string()),
                     Err(_) => Response::NotFound
                 };
 

--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -47,7 +47,7 @@ pub struct CPasswd {
 #[macro_export]
 macro_rules! libnss_passwd_hooks {
 ($mod_ident:ident, $hooks_ident:ident) => (
-    paste::item! {
+    $crate::_macro_internal::paste! {
         pub use self::[<libnss_passwd_ $mod_ident _hooks_impl>]::*;
         mod [<libnss_passwd_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]
@@ -59,7 +59,7 @@ macro_rules! libnss_passwd_hooks {
             use $crate::interop::{CBuffer, Iterator, Response, NssStatus};
             use $crate::passwd::{CPasswd, Passwd, PasswdHooks};
 
-            lazy_static! {
+            $crate::_macro_internal::lazy_static! {
             static ref [<PASSWD_ $mod_ident _ITERATOR>]: Mutex<Iterator<Passwd>> = Mutex::new(Iterator::<Passwd>::new());
             }
 

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -69,7 +69,7 @@ macro_rules! libnss_shadow_hooks {
             #[no_mangle]
             extern "C" fn [<_nss_ $mod_ident _setspent>]() -> c_int {
                 let mut iter: MutexGuard<Iterator<Shadow>> = [<SHADOW_ $mod_ident _ITERATOR>].lock().unwrap();
-                let status = match(super::$hooks_ident::get_all_entries()) {
+                let status = match(<super::$hooks_ident as ShadowHooks>::get_all_entries()) {
                     Response::Success(entries) => iter.open(entries),
                     response => response.to_status()
                 };
@@ -108,7 +108,7 @@ macro_rules! libnss_shadow_hooks {
                 let cstr = CStr::from_ptr(name_);
 
                 match str::from_utf8(cstr.to_bytes()) {
-                    Ok(name) => super::$hooks_ident::get_entry_by_name(name.to_string()),
+                    Ok(name) => <super::$hooks_ident as ShadowHooks>::get_entry_by_name(name.to_string()),
                     Err(_) => Response::NotFound
                 }.to_c(result, buf, buflen, errnop) as c_int
             }

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -50,7 +50,7 @@ pub struct CShadow {
 #[macro_export]
 macro_rules! libnss_shadow_hooks {
 ($mod_ident:ident, $hooks_ident:ident) => (
-    paste::item! {
+    $crate::_macro_internal::paste! {
         pub use self::[<libnss_shadow_ $mod_ident _hooks_impl>]::*;
         mod [<libnss_shadow_ $mod_ident _hooks_impl>] {
             #![allow(non_upper_case_globals)]
@@ -62,7 +62,7 @@ macro_rules! libnss_shadow_hooks {
             use $crate::interop::{CBuffer, Iterator, Response, NssStatus};
             use $crate::shadow::{CShadow, ShadowHooks, Shadow};
 
-            lazy_static! {
+            $crate::_macro_internal::lazy_static! {
             static ref [<SHADOW_ $mod_ident _ITERATOR>]: Mutex<Iterator<Shadow>> = Mutex::new(Iterator::<Shadow>::new());
             }
 


### PR DESCRIPTION
Currently the macros require dependency macros like `paste` and `lazy_static` to be in scope at the use site, which requires downstream consumers to add those crates as dependencies themselves. This PR changes the macro implementations to use a hidden re-export in the crate itself, which removes the need for any imports of `paste` and `lazy_static` at the use site.

Additionally, macro implementations have been tweaked to look up methods on the trait directly (instead of relying on name resolution with the trait in scope), so that error messages are clearer when the trait has not been implemented on the type:
```
error[E0277]: the trait bound `HardcodedPasswd: PasswdHooks` is not satisfied
  --> example-hardcoded/src/lib.rs:13:1
   |
13 | libnss_passwd_hooks!(hardcoded, HardcodedPasswd);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PasswdHooks` is not implemented for `HardcodedPasswd`
   |
   = note: this error originates in the macro `libnss_passwd_hooks` (in Nightly builds, run with -Z macro-backtrace for more info)
   ```