### PR TITLE
Support freebsd passwd struct

### DIFF
--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -39,9 +39,17 @@ pub struct CPasswd {
     pub passwd: *mut libc::c_char,
     pub uid: libc::uid_t,
     pub gid: libc::gid_t,
+    #[cfg(target_os = "freebsd")]
+    pub pw_change: libc::time_t,
+    #[cfg(target_os = "freebsd")]
+    pub pw_class: *mut libc::c_char,
     pub gecos: *mut libc::c_char,
     pub dir: *mut libc::c_char,
     pub shell: *mut libc::c_char,
+    #[cfg(target_os = "freebsd")]
+    pub pw_expire: libc::time_t,
+    #[cfg(target_os = "freebsd")]
+    pub pw_fields: i32
 }
 
 #[macro_export]


### PR DESCRIPTION
The freebsd passwd struct has extra fields compared to the standard glibc one. While freebsd offers a compat bridge for the function calls, they *don't* remap the struct fields. 

This leads to users resolving as:

```
william:x:654401105:654401105:/usr/local/bin/zsh:     :
name:pw:uid:gid:gecos:home:shell
```

The cause is the fields in freebsd for pw_change and pw_class, that misalign to the glibc struct.

```
	     struct passwd {
		     char    *pw_name;	     /*	user name */
		     char    *pw_passwd;     /*	encrypted password */
		     uid_t   pw_uid;	     /*	user uid */
		     gid_t   pw_gid;	     /*	user gid */
		     time_t  pw_change;	     /*	password change	time */
		     char    *pw_class;	     /*	user access class */
		     char    *pw_gecos;	     /*	Honeywell login	info */
		     char    *pw_dir;	     /*	home directory */
		     char    *pw_shell;	     /*	default	shell */
		     time_t  pw_expire;	     /*	account	expiration */
		     int     pw_fields;	     /*	internal: fields filled	in */
	     };
```

```
           struct passwd {
               char   *pw_name;       /* username */
               char   *pw_passwd;     /* user password */
               uid_t   pw_uid;        /* user ID */
               gid_t   pw_gid;        /* group ID */
               char   *pw_gecos;      /* user information */
               char   *pw_dir;        /* home directory */
               char   *pw_shell;      /* shell program */
           };
```

This adds empty placeholders for the unused struct elements when freebsd is used as a built target, so that the remaining fields are in the correct places. No changes to group are needed. 