### PR TITLE
Implement service NSS hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Currently supports the following databases:
 - shadow
 - group
 - hosts
+- services
 
 ## Getting started
 - Create a new library

--- a/libnss/src/group.rs
+++ b/libnss/src/group.rs
@@ -78,7 +78,7 @@ macro_rules! libnss_group_hooks {
                 errnop: *mut c_int
             ) -> c_int {
                 let mut iter: MutexGuard<Iterator<Group>> = [<GROUP_ $mod_ident _ITERATOR>].lock().unwrap();
-                let code: c_int = iter.next().to_c(result, buf, buflen, errnop) as c_int;
+                let code: c_int = iter.next().to_c(result, buf, buflen, Some(errnop)) as c_int;
                 if code == NssStatus::TryAgain as c_int {
                     iter.previous();
                 }
@@ -97,7 +97,7 @@ macro_rules! libnss_group_hooks {
                     result,
                     buf,
                     buflen,
-                    errnop
+                    Some(errnop)
                 ) as c_int
             }
 
@@ -114,7 +114,7 @@ macro_rules! libnss_group_hooks {
                 match str::from_utf8(cstr.to_bytes()) {
                     Ok(name) => <super::$hooks_ident as GroupHooks>::get_entry_by_name(name.to_string()),
                     Err(_) => Response::NotFound
-                }.to_c(result, buf, buflen, errnop) as c_int
+                }.to_c(result, buf, buflen, Some(errnop)) as c_int
             }
         }
     }

--- a/libnss/src/host.rs
+++ b/libnss/src/host.rs
@@ -154,7 +154,7 @@ macro_rules! libnss_host_hooks {
             unsafe extern "C" fn [<_nss_ $mod_ident _gethostent_r>](result: *mut CHost, buf: *mut libc::c_char, buflen: libc::size_t,
                                                                   errnop: *mut c_int) -> c_int {
                 let mut iter: MutexGuard<Iterator<Host>> = [<HOST_ $mod_ident _ITERATOR>].lock().unwrap();
-                let code: c_int = iter.next().to_c(result, buf, buflen, errnop) as c_int;
+                let code: c_int = iter.next().to_c(result, buf, buflen, Some(errnop)) as c_int;
                 if code == NssStatus::TryAgain as c_int {
                     iter.previous();
                 }
@@ -198,7 +198,7 @@ macro_rules! libnss_host_hooks {
                         response
                     },
                     response => response
-                }.to_c(result, buf, buflen, errnop) as c_int
+                }.to_c(result, buf, buflen, Some(errnop)) as c_int
             }
 
             #[no_mangle]
@@ -268,7 +268,7 @@ macro_rules! libnss_host_hooks {
                                 *h_errnop = Herrno::NoRecovery as i32;
                                 Response::Unavail
                             },
-                        }.to_c(result, buf, buflen, errnop);
+                        }.to_c(result, buf, buflen, Some(errnop));
 
                         match status {
                             NssStatus::Success => {

--- a/libnss/src/lib.rs
+++ b/libnss/src/lib.rs
@@ -3,6 +3,7 @@ pub mod host;
 pub mod initgroups;
 pub mod interop;
 pub mod passwd;
+pub mod service;
 pub mod shadow;
 
 /// Re-exports for use by macros

--- a/libnss/src/passwd.rs
+++ b/libnss/src/passwd.rs
@@ -97,7 +97,7 @@ macro_rules! libnss_passwd_hooks {
                 errnop: *mut c_int
             ) -> c_int {
                 let mut iter: MutexGuard<Iterator<Passwd>> = [<PASSWD_ $mod_ident _ITERATOR>].lock().unwrap();
-                let code: c_int = iter.next().to_c(result, buf, buflen, errnop) as c_int;
+                let code: c_int = iter.next().to_c(result, buf, buflen, Some(errnop)) as c_int;
                 if code == NssStatus::TryAgain as c_int {
                     iter.previous();
                 }
@@ -112,7 +112,7 @@ macro_rules! libnss_passwd_hooks {
                 buflen: libc::size_t,
                 errnop: *mut c_int
             ) -> c_int {
-                <super::$hooks_ident as PasswdHooks>::get_entry_by_uid(uid).to_c(result, buf, buflen, errnop) as c_int
+                <super::$hooks_ident as PasswdHooks>::get_entry_by_uid(uid).to_c(result, buf, buflen, Some(errnop)) as c_int
             }
 
             #[no_mangle]
@@ -130,7 +130,7 @@ macro_rules! libnss_passwd_hooks {
                     Err(_) => Response::NotFound
                 };
 
-                response.to_c(result, buf, buflen, errnop) as c_int
+                response.to_c(result, buf, buflen, Some(errnop)) as c_int
             }
         }
     }

--- a/libnss/src/service.rs
+++ b/libnss/src/service.rs
@@ -1,0 +1,167 @@
+use crate::interop::{CBuffer, Response, ToC};
+
+#[derive(Clone)]
+pub struct Service {
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub port: u16,
+    pub proto: String,
+}
+
+impl ToC<CService> for Service {
+    unsafe fn to_c(&self, result: *mut CService, buffer: &mut CBuffer) -> std::io::Result<()> {
+        (*result).s_name = buffer.write_str(&self.name)?;
+        (*result).s_aliases = buffer.write_strs(&self.aliases[..])?;
+        (*result).s_port = self.port.to_be() as libc::c_int;
+        (*result).s_proto = buffer.write_str(&self.proto)?;
+        Ok(())
+    }
+}
+
+pub trait ServiceHooks {
+    fn get_all_entries() -> Response<Vec<Service>>;
+
+    fn get_service_by_name(name: &str, proto: Option<&str>) -> Response<Service>;
+
+    fn get_service_by_port(port: u16, proto: Option<&str>) -> Response<Service>;
+}
+
+#[repr(C)]
+#[allow(missing_copy_implementations)]
+pub struct CService {
+    pub s_name: *mut libc::c_char,
+    pub s_aliases: *mut *mut libc::c_char,
+    pub s_port: libc::c_int,
+    pub s_proto: *mut libc::c_char,
+}
+
+#[macro_export]
+macro_rules! libnss_service_hooks {
+($mod_ident:ident, $hooks_ident:ident) => (
+    $crate::_macro_internal::paste! {
+        pub use self::[<libnss_service_ $mod_ident _hooks_impl>]::*;
+        mod [<libnss_service_ $mod_ident _hooks_impl>] {
+            #![allow(non_upper_case_globals)]
+
+            use libc::c_int;
+            use std::ffi::CStr;
+            use std::ptr::null_mut;
+            use std::str;
+            use std::sync::{Mutex, MutexGuard};
+            use $crate::interop::{CBuffer, Iterator, Response, NssStatus};
+            use $crate::service::{CService, Service, ServiceHooks};
+
+            $crate::_macro_internal::lazy_static! {
+            static ref [<SERVICE_ $mod_ident _ITERATOR>]: Mutex<Iterator<Service>> = Mutex::new(Iterator::<Service>::new());
+            }
+
+            unsafe fn convert_proto<'a>(proto: *const libc::c_char) -> Response<Option<&'a str>> {
+                if proto.is_null() {
+                    Response::Success(None)
+                } else {
+                    if let Ok(proto) = str::from_utf8(CStr::from_ptr(proto).to_bytes()) {
+                        Response::Success(Some(proto))
+                    } else {
+                        Response::NotFound
+                    }
+                }
+            }
+
+            #[no_mangle]
+            extern "C" fn [<_nss_ $mod_ident _setservent>]() -> c_int {
+                let mut iter: MutexGuard<Iterator<Service>> = [<SERVICE_ $mod_ident _ITERATOR>].lock().unwrap();
+
+                let status = match(<super::$hooks_ident as ServiceHooks>::get_all_entries()) {
+                    Response::Success(entries) => iter.open(entries),
+                    response => response.to_status()
+                };
+
+                status as c_int
+            }
+
+            #[no_mangle]
+            extern "C" fn [<_nss_ $mod_ident _endservent>]() -> c_int {
+                let mut iter: MutexGuard<Iterator<Service>> = [<SERVICE_ $mod_ident _ITERATOR>].lock().unwrap();
+                iter.close() as c_int
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn [<_nss_ $mod_ident _getservent_r>](
+                result_buf: *mut CService,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                result: *mut *mut CService
+            ) -> c_int {
+                let mut iter: MutexGuard<Iterator<Service>> = [<SERVICE_ $mod_ident _ITERATOR>].lock().unwrap();
+                let code: c_int = iter.next().to_c(result_buf, buf, buflen, None) as c_int;
+                if code == NssStatus::TryAgain as c_int {
+                    iter.previous();
+                }
+                if code == NssStatus::Success as c_int {
+                    *result = result_buf;
+                } else {
+                    *result = null_mut();
+                }
+                return code;
+            }
+
+            #[no_mangle]
+            unsafe extern "C" fn [<_nss_ $mod_ident _getservbyname_r>](
+                name: *const libc::c_char,
+                proto: *const libc::c_char,
+                result_buf: *mut CService,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                result: *mut *mut CService
+            ) -> c_int {
+                let c_name = CStr::from_ptr(name);
+
+                let proto_result = convert_proto(proto);
+                let proto = match proto_result {
+                    Response::Success(proto) => proto,
+                    _ => {
+                        return proto_result.to_status() as c_int;
+                    }
+                };
+
+                let response = match str::from_utf8(c_name.to_bytes()) {
+                    Ok(name) => <super::$hooks_ident as ServiceHooks>::get_service_by_name(name, proto),
+                    Err(_) => Response::NotFound
+                };
+
+                let code: c_int = response.to_c(result_buf, buf, buflen, None) as c_int;
+                if code == NssStatus::Success as c_int {
+                    *result = result_buf;
+                } else {
+                    *result = null_mut();
+                }
+                return code;
+            }
+
+           #[no_mangle]
+            unsafe extern "C" fn [<_nss_ $mod_ident _getservbyport_r>](
+                port: i32,
+                proto: *const libc::c_char,
+                result_buf: *mut CService,
+                buf: *mut libc::c_char,
+                buflen: libc::size_t,
+                result: *mut *mut CService
+            ) -> c_int {
+                let proto_result = convert_proto(proto);
+                let response = match proto_result {
+                    Response::Success(proto) =>
+                        <super::$hooks_ident as ServiceHooks>::get_service_by_port(u16::from_be(port as u16), proto),
+                    _ => Response::NotFound,
+                };
+
+                let code: c_int = response.to_c(result_buf, buf, buflen, None) as c_int;
+                if code == NssStatus::Success as c_int {
+                    *result = result_buf;
+                } else {
+                    *result = null_mut();
+                }
+                return code;
+            }
+        }
+    })
+}

--- a/libnss/src/shadow.rs
+++ b/libnss/src/shadow.rs
@@ -90,7 +90,7 @@ macro_rules! libnss_shadow_hooks {
                 errnop: *mut c_int
             ) -> c_int {
                 let mut iter: MutexGuard<Iterator<Shadow>> = [<SHADOW_ $mod_ident _ITERATOR>].lock().unwrap();
-                let code: c_int = iter.next().to_c(result, buf, buflen, errnop) as c_int;
+                let code: c_int = iter.next().to_c(result, buf, buflen, Some(errnop)) as c_int;
                 if code == NssStatus::TryAgain as c_int {
                     iter.previous();
                 }
@@ -110,7 +110,7 @@ macro_rules! libnss_shadow_hooks {
                 match str::from_utf8(cstr.to_bytes()) {
                     Ok(name) => <super::$hooks_ident as ShadowHooks>::get_entry_by_name(name.to_string()),
                     Err(_) => Response::NotFound
-                }.to_c(result, buf, buflen, errnop) as c_int
+                }.to_c(result, buf, buflen, Some(errnop)) as c_int
             }
         }
     }


### PR DESCRIPTION
This implements NSS hooks for the services database. The implementation follows the existing NSS services that are already supported by libnss.